### PR TITLE
fix: Use title of page instead of title of frontmatter.

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,7 +27,7 @@ module.exports = (pluginOptions, ctx) => {
         .map(page => ({...page, date: new Date(page.frontmatter.date || '')}))
         .sort((a, b) => b.date - a.date)
         .map(page => ({
-          title: page.frontmatter.title,
+          title: page.title,
           description: page.excerpt,
           url: `${pluginOptions.site_url}${page.path}`,
           date: page.date,


### PR DESCRIPTION
I think use `page.title` is better than `page.frontmatter.title`, you can still override title in front matter, but the content of first heading will be used as title by default, and it reduce lots of boilerplate writing `title: xxx` in front matter